### PR TITLE
Update actions/checkout and coursier/setup-action

### DIFF
--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -11,9 +11,9 @@ jobs:
     outputs:
       version: ${{ steps.nightly.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: coursier/setup-action@v1
+      - uses: coursier/setup-action@v3
         with:
           apps: scala-cli:1.12.3
           jvm: "temurin:25"

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -79,7 +79,7 @@ jobs:
       runs_array: ${{ steps.publish.outputs.runs_array }}
     steps:
       - name: Checkout dotty PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: scala/scala3
           ref: refs/pull/${{ inputs.pr }}/head
@@ -87,7 +87,7 @@ jobs:
           path: dotty
 
       - name: Setup Coursier
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: "temurin:25"
 

--- a/.github/workflows/benchmark-weekly.yml
+++ b/.github/workflows/benchmark-weekly.yml
@@ -11,9 +11,9 @@ jobs:
     outputs:
       version: ${{ steps.nightly.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: coursier/setup-action@v1
+      - uses: coursier/setup-action@v3
         with:
           apps: scala-cli:1.12.3
           jvm: "temurin:25"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,10 +43,10 @@ jobs:
         id: timestamp
         run: echo "ts=$(date +'%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Coursier
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           apps: scala-cli:1.12.3
           jvm: "temurin:25"
@@ -72,7 +72,7 @@ jobs:
           ssh-keyscan github.com >> ~/.ssh/known_hosts
 
       - name: Checkout data repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: lampepfl/scala3-benchmarks-data
           path: data-repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           - "3.7.4"
           - "3.8.1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/deploy-visualizer.yml
+++ b/.github/workflows/deploy-visualizer.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Should fix this GitHub warning when running benchmarks:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, coursier/setup-action@v1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/