### PR TITLE
Stop compiling with -Werror

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val compilerVersion = sys.props.get("compiler.version").getOrElse("3.8.1")
 
-val sharedScalacOptions = Seq("-feature", "-Werror", "-deprecation")
+val sharedScalacOptions = Seq("-feature", "-deprecation")
 
 ThisBuild / resolvers += Resolver.scalaNightlyRepository
 


### PR DESCRIPTION
We currently have deprecation warnings from macros in some bench source due to the `->` change (it's now inline).

I don't even want to think about how to fix them, and anyway we can benchmark stuff even if it has warnings.